### PR TITLE
Fix format strings

### DIFF
--- a/src/glfw3.zig
+++ b/src/glfw3.zig
@@ -511,7 +511,7 @@ fn errorCheck() !void{
 fn errorCheck2() void{
     const r = errorCheck() catch |err|{
         if(err != GLFWError.NoError){
-            std.debug.warn("error: {}\n", .{@errorName(err)});
+            std.debug.warn("error: {s}\n", .{@errorName(err)});
         }
     };
 }


### PR DESCRIPTION
In the master branch for Zig, format strings were updated to use {s} for strings to avoid ambiguity with normal u8 slices. This pull request edits the code to make it compatible with said update.