### PR TITLE
Change name for C call convention to lowercase to match Zig builtin

### DIFF
--- a/src/glfw.zig
+++ b/src/glfw.zig
@@ -448,7 +448,7 @@ else if (builtin.abi == .android and (builtin.cpu.arch.isARM() or builtin.cpu.ar
     // as it does by default when compiling for the armeabi-v7a NDK ABI.
     .AAPCSVFP
 else
-    .C;
+    .c;
 
 pub const VkAllocationCallbacks = extern struct {
     p_user_data: ?*anyopaque = null,


### PR DESCRIPTION
Just to preface that I'm new to Zig, so may be mistaking something here.
But running with Vulkan on macos, this function tries to refers to `.C` call convention but in the zig builtin it is lowercase.

```Zig
pub const c = builtin.target.cCallingConvention().?;
```

Changing seems to have got rid of the error.